### PR TITLE
WUI: drop the redundant CNAME file

### DIFF
--- a/.github/workflows/wui.yml
+++ b/.github/workflows/wui.yml
@@ -47,8 +47,6 @@ jobs:
         uses: actions/configure-pages@v6
       - name: Upload Pages artifact
         # path is relative to the repo root (not the job's working-directory).
-        # dist/ already contains the CNAME file copied from public/CNAME, which
-        # keeps the passwords.ledger.com custom domain.
         uses: actions/upload-pages-artifact@v5
         with:
           path: clients/wui/dist/

--- a/clients/wui/public/CNAME
+++ b/clients/wui/public/CNAME
@@ -1,1 +1,0 @@
-passwords.ledger.com


### PR DESCRIPTION
## Description

The custom domain passwords.ledger.com is pinned server-side in the repo Pages settings. With the official GitHub Pages Action the domain no longer comes from a CNAME file in the artifact, so public/CNAME is redundant. Remove it.

